### PR TITLE
Qm1.22.2 hotfixes

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
@@ -246,7 +246,9 @@ public class XTextInputPlugin {
             if (isInputConnectionLocked) {
                 return lastInputConnection;
             }
-            lastInputConnection = platformViewsController.getPlatformViewById(inputTarget.id).onCreateInputConnection(outAttrs);
+            if (platformViewsController != null && platformViewsController.getPlatformViewById(inputTarget.id) != null) {
+                lastInputConnection = platformViewsController.getPlatformViewById(inputTarget.id).onCreateInputConnection(outAttrs);
+            }
             return lastInputConnection;
         }
 


### PR DESCRIPTION
解决如下crash: Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.inputmethod.InputConnection android.view.View.onCreateInputConnection(android.view.inputmethod.EditorInfo)' on a null object reference
       at com.idlefish.flutterboost.XTextInputPlugin.createInputConnection(XTextInputPlugin.java:249)