### PR TITLE
解决Fatal Exception: java.lang.RuntimeException: Failure delivering res…

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
@@ -291,7 +291,11 @@ public class BoostFlutterActivity extends Activity
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        delegate.onActivityResult(requestCode, resultCode, data);
+        try {
+            delegate.onActivityResult(requestCode, resultCode, data);
+        } catch (Exception e) {
+
+        }
     }
 
     @Override


### PR DESCRIPTION
…ult ResultInfo{who=null, request=64206, result=-1, data=Intent { (has extras) }} to activity {com.explore.fanci/com.startap.core.flutter.StartapSplashActivity}: java.lang.IllegalStateException: Reply already submitted